### PR TITLE
Add upstream release sync workflow and script

### DIFF
--- a/.github/workflows/check-upstream-releases.yml
+++ b/.github/workflows/check-upstream-releases.yml
@@ -1,0 +1,167 @@
+name: Check Upstream OpenClaw Releases
+
+on:
+  schedule:
+    # Run daily at 08:00 UTC
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  check-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout enterprise repo
+        uses: actions/checkout@v4
+
+      - name: Get current enterprise version
+        id: enterprise
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current enterprise version: $VERSION"
+
+      - name: Fetch upstream releases
+        id: upstream
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch the latest 20 releases from upstream openclaw/openclaw
+          RELEASES=$(gh api repos/openclaw/openclaw/releases --paginate --jq '.[].tag_name' | head -20)
+          LATEST=$(echo "$RELEASES" | head -1)
+
+          # Strip leading 'v' for comparison
+          LATEST_CLEAN="${LATEST#v}"
+          echo "latest=$LATEST_CLEAN" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Latest upstream release: $LATEST_CLEAN"
+
+      - name: Compare versions and collect missing releases
+        id: compare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENTERPRISE_VERSION: ${{ steps.enterprise.outputs.version }}
+          LATEST_UPSTREAM: ${{ steps.upstream.outputs.latest }}
+        run: |
+          if [ "$ENTERPRISE_VERSION" = "$LATEST_UPSTREAM" ]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "Enterprise is up to date with upstream."
+            exit 0
+          fi
+
+          echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+
+          # Collect all stable releases newer than the enterprise version
+          MISSING=""
+          while IFS= read -r tag; do
+            ver="${tag#v}"
+            # Skip pre-releases (beta, alpha, rc)
+            if echo "$ver" | grep -qiE '(alpha|beta|rc)'; then
+              continue
+            fi
+            # Compare: upstream release is newer if it sorts after enterprise version
+            if [ "$(printf '%s\n%s' "$ENTERPRISE_VERSION" "$ver" | sort -V | tail -1)" = "$ver" ] && [ "$ver" != "$ENTERPRISE_VERSION" ]; then
+              MISSING="$MISSING$tag\n"
+            fi
+          done <<< "$(gh api repos/openclaw/openclaw/releases --paginate --jq '.[].tag_name' | head -20)"
+
+          MISSING=$(echo -e "$MISSING" | sed '/^$/d')
+          COUNT=$(echo "$MISSING" | wc -l)
+
+          echo "missing_releases<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$MISSING" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          echo "missing_count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Missing releases ($COUNT): $MISSING"
+
+      - name: Check for existing tracking issue
+        if: steps.compare.outputs.up_to_date == 'false'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_TAG: ${{ steps.upstream.outputs.latest_tag }}
+        run: |
+          EXISTING=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "upstream-sync" \
+            --state open \
+            --search "Upstream sync: $LATEST_TAG" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "issue_number=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Tracking issue #$EXISTING already exists."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure upstream-sync label exists
+        if: steps.compare.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "upstream-sync" \
+            --repo "$GITHUB_REPOSITORY" \
+            --description "Tracks upstream openclaw/openclaw release syncs" \
+            --color "0E8A16" \
+            --force
+
+      - name: Create tracking issue
+        if: steps.compare.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENTERPRISE_VERSION: ${{ steps.enterprise.outputs.version }}
+          LATEST_TAG: ${{ steps.upstream.outputs.latest_tag }}
+          LATEST_UPSTREAM: ${{ steps.upstream.outputs.latest }}
+          MISSING_RELEASES: ${{ steps.compare.outputs.missing_releases }}
+          MISSING_COUNT: ${{ steps.compare.outputs.missing_count }}
+        run: |
+          BODY=$(cat <<'ISSUE_EOF'
+          ## Upstream Release Sync Required
+
+          **Enterprise version:** `ENTERPRISE_VERSION_PLACEHOLDER`
+          **Latest upstream release:** `LATEST_TAG_PLACEHOLDER`
+          **Missing releases:** MISSING_COUNT_PLACEHOLDER
+
+          ### Releases to sync
+
+          MISSING_RELEASES_PLACEHOLDER
+
+          ### Checklist
+
+          - [ ] Review upstream changelog for breaking changes
+          - [ ] Merge/rebase upstream changes into enterprise
+          - [ ] Update `package.json` version
+          - [ ] Update `CHANGELOG.md` with upstream changes
+          - [ ] Run full test suite (`pnpm test`)
+          - [ ] Verify enterprise features still work (`pnpm test:enterprise-e2e`)
+          - [ ] Update any enterprise patches affected by upstream changes
+
+          ### Links
+
+          - [Upstream releases](https://github.com/openclaw/openclaw/releases)
+          - [Upstream changelog](https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md)
+          ISSUE_EOF
+
+          BODY="${BODY//ENTERPRISE_VERSION_PLACEHOLDER/$ENTERPRISE_VERSION}"
+          BODY="${BODY//LATEST_TAG_PLACEHOLDER/$LATEST_TAG}"
+          BODY="${BODY//MISSING_COUNT_PLACEHOLDER/$MISSING_COUNT}"
+
+          # Format missing releases as a checklist
+          RELEASES_LIST=""
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            RELEASES_LIST="$RELEASES_LIST- [ ] [\`$tag\`](https://github.com/openclaw/openclaw/releases/tag/$tag)\n"
+          done <<< "$MISSING_RELEASES"
+          BODY="${BODY//MISSING_RELEASES_PLACEHOLDER/$(echo -e "$RELEASES_LIST")}"
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Upstream sync: $LATEST_TAG (enterprise is at v$ENTERPRISE_VERSION)" \
+            --body "$BODY" \
+            --label "upstream-sync"

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# sync-upstream.sh — Sync OpenClaw Enterprise with upstream openclaw/openclaw releases
+#
+# Usage:
+#   ./scripts/sync-upstream.sh                  # Show status & missing releases
+#   ./scripts/sync-upstream.sh --merge <tag>    # Merge a specific upstream tag
+#
+# Prerequisites:
+#   - git remote 'upstream' pointing to openclaw/openclaw
+#     (the script will add it automatically if missing)
+set -euo pipefail
+
+UPSTREAM_REMOTE="upstream"
+UPSTREAM_REPO="https://github.com/openclaw/openclaw.git"
+ENTERPRISE_VERSION=$(jq -r '.version' package.json)
+
+# ── Ensure upstream remote exists ────────────────────────────────────────────
+if ! git remote get-url "$UPSTREAM_REMOTE" &>/dev/null; then
+  echo "Adding upstream remote: $UPSTREAM_REPO"
+  git remote add "$UPSTREAM_REMOTE" "$UPSTREAM_REPO"
+fi
+
+# ── Fetch upstream tags ──────────────────────────────────────────────────────
+echo "Fetching upstream tags..."
+git fetch "$UPSTREAM_REMOTE" --tags --force
+
+# ── List missing releases ────────────────────────────────────────────────────
+echo ""
+echo "Enterprise version: v$ENTERPRISE_VERSION"
+echo ""
+
+MISSING_TAGS=()
+for tag in $(git tag -l 'v20*' --sort=-version:refname); do
+  ver="${tag#v}"
+  # Skip pre-releases
+  if echo "$ver" | grep -qiE '(alpha|beta|rc)'; then
+    continue
+  fi
+  # Check if this version is newer than enterprise
+  if [ "$(printf '%s\n%s' "$ENTERPRISE_VERSION" "$ver" | sort -V | tail -1)" = "$ver" ] && [ "$ver" != "$ENTERPRISE_VERSION" ]; then
+    MISSING_TAGS+=("$tag")
+  fi
+done
+
+if [ ${#MISSING_TAGS[@]} -eq 0 ]; then
+  echo "Enterprise is up to date with upstream."
+  exit 0
+fi
+
+echo "Missing upstream releases (oldest first):"
+for ((i=${#MISSING_TAGS[@]}-1; i>=0; i--)); do
+  echo "  - ${MISSING_TAGS[$i]}"
+done
+echo ""
+
+# ── Merge mode ───────────────────────────────────────────────────────────────
+if [ "${1:-}" = "--merge" ]; then
+  TARGET_TAG="${2:-}"
+  if [ -z "$TARGET_TAG" ]; then
+    echo "Error: --merge requires a tag argument (e.g., v2026.3.23)"
+    exit 1
+  fi
+
+  # Verify tag exists
+  if ! git rev-parse "$TARGET_TAG" &>/dev/null; then
+    echo "Error: tag '$TARGET_TAG' not found. Run the script without flags to see available tags."
+    exit 1
+  fi
+
+  echo "Merging upstream $TARGET_TAG into current branch..."
+  echo ""
+
+  BRANCH=$(git branch --show-current)
+  echo "Current branch: $BRANCH"
+  echo ""
+
+  # Attempt the merge — conflicts are expected and will need manual resolution
+  if git merge "$TARGET_TAG" --no-edit -m "chore: merge upstream $TARGET_TAG into enterprise"; then
+    echo ""
+    echo "Merge successful! Next steps:"
+    echo "  1. Update version in package.json to match upstream"
+    echo "  2. Update CHANGELOG.md with upstream changes"
+    echo "  3. Run: pnpm install"
+    echo "  4. Run: pnpm test"
+    echo "  5. Run: pnpm test:enterprise-e2e"
+  else
+    echo ""
+    echo "Merge has conflicts. Please resolve them manually:"
+    echo "  1. Fix conflicts in the listed files"
+    echo "  2. git add <resolved files>"
+    echo "  3. git merge --continue"
+    echo "  4. Update version in package.json"
+    echo "  5. Run: pnpm test && pnpm test:enterprise-e2e"
+  fi
+
+  exit 0
+fi
+
+# ── Default: just show status ────────────────────────────────────────────────
+LATEST="${MISSING_TAGS[0]}"
+echo "To merge the latest upstream release:"
+echo "  ./scripts/sync-upstream.sh --merge $LATEST"
+echo ""
+echo "To merge releases incrementally (recommended):"
+OLDEST="${MISSING_TAGS[${#MISSING_TAGS[@]}-1]}"
+echo "  ./scripts/sync-upstream.sh --merge $OLDEST"


### PR DESCRIPTION
## Summary

- Add a **daily GitHub Actions workflow** (`.github/workflows/check-upstream-releases.yml`) that checks `openclaw/openclaw` for new releases and automatically creates a tracking issue with an `upstream-sync` label when the enterprise fork falls behind
- Add a **manual sync script** (`scripts/sync-upstream.sh`) that sets up the upstream remote, lists missing releases, and supports merging specific upstream tags into the enterprise fork
- Enterprise is currently at **v2026.2.22** while upstream is at **v2026.3.23** (missing 3 stable releases: v2026.3.13-1, v2026.3.22, v2026.3.23)

## How it works

**Automated workflow** (runs daily at 08:00 UTC + manual trigger):
1. Reads current version from `package.json`
2. Fetches releases from `openclaw/openclaw` via GitHub API
3. Compares versions, skipping pre-releases
4. Creates a tracking issue with checklist if new releases are found (deduplicates by checking for existing open issues)

**Manual sync script**:
```bash
./scripts/sync-upstream.sh                  # Show status & missing releases
./scripts/sync-upstream.sh --merge v2026.3.23  # Merge a specific upstream tag
```

## Test plan

- [ ] Verify workflow syntax is valid (`workflow-sanity` CI check)
- [ ] Trigger workflow manually via `workflow_dispatch` to confirm it detects the 3 missing releases
- [ ] Run `./scripts/sync-upstream.sh` locally to verify upstream remote setup and tag listing
- [ ] Test `--merge` flow on a throwaway branch

https://claude.ai/code/session_014dhfA5gfterF2jBYPrB7xs